### PR TITLE
ci(test-helm-install): fix no-values assertion

### DIFF
--- a/.github/workflows/test-helm-install.yaml
+++ b/.github/workflows/test-helm-install.yaml
@@ -30,9 +30,9 @@ jobs:
           export KUBECONFIG=./kubeconfig.yaml
           helm status podinfo -n default | grep -E '^STATUS: deployed'
           kubectl rollout status deployment/podinfo -n default --timeout=2m
-          # Confirm no user-supplied values were applied
+          # Confirm no user-supplied values were applied (helm prints "null" on its own line)
           helm get values podinfo -n default | tee values.out
-          grep -E '^USER-SUPPLIED VALUES: null$' values.out
+          grep -Fxq null values.out
       - name: Remove Cluster
         if: always()
         uses: replicatedhq/replicated-actions/remove-cluster@v1


### PR DESCRIPTION
## Summary
The no-values scenario was failing because the assertion expected `USER-SUPPLIED VALUES: null` on a single line, but helm prints them on two:

```
USER-SUPPLIED VALUES:
null
```

Switch to `grep -Fxq null values.out`, which confirms a bare `null` line is present.

## Test plan
- [ ] Trigger `test-helm-install` via `workflow_dispatch`
- [ ] All three jobs pass